### PR TITLE
add protocol definition and update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "0.4"
+prost = "0.5"
+prost-types = "0.8"
+
+[build-dependencies]
+prost-build = "0.5"

--- a/src/decide.proto
+++ b/src/decide.proto
@@ -1,23 +1,21 @@
 syntax = "proto3";
 import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
 
 package decide;
 
-/* The payload for a requested state change to a component. Component state may
-   be a scalar (int32) or a label (string) */
+/* The payload for a requested state change to a component. Components must
+   define a protobuf message type for their state */
 message StateChange {
   string component = 1;
-  oneof state {
-    int32 scalar = 4;
-    string label = 5;
-  }
+  google.protobuf.Any state = 2;
 }
 
-/* The payload for a requested change to the parameters for a component */
+/* The payload for a requested change to the parameters for a component.
+   Components must define a protobuf message type for their parameters */
 message ComponentParams {
   string component = 1;
-  // The documentation for the component must define how the parameter value will be parsed from the string.
-  map<string, string> parameters = 2;
+  google.protobuf.Any parameters = 2;
 }
 
 /* This is what gets sent on the wire */
@@ -47,13 +45,13 @@ message Request {
 message Reply {
   string protocol = 1;
   oneof reply {
-    // For state_change, state_reset, lock_expt, unlock_expt, shutdown:
+    // For state_change, state_reset, lock_expt, unlock_expt:
     // indicates the request was correctly formed and was acted on
     google.protobuf.Empty ok = 2;
     // indicates an error with the request, contents give the cause
     string error = 3;
     // reply to get_parameters
-    map<string, string> params = 19;
+    google.protobuf.Any params = 19;
     // reply to get_component_config, and get_controller_config
     map<string, string> config = 20;
   }

--- a/src/decide.proto
+++ b/src/decide.proto
@@ -32,8 +32,6 @@ message Request {
     string lock_expt = 16;
     // request unlock of experiment. Reply type is ok or error
     google.protobuf.Empty unlock_expt = 17;
-    // request shutdown of controller. Reply type is ok or error
-    google.protobuf.Empty shutdown = 18;
     // request update to parameter values. Reply type is ok or error.
     ComponentParams set_parameters = 19;
     // request parameter values for component. Reply type is params or error.

--- a/src/decide.proto
+++ b/src/decide.proto
@@ -1,0 +1,78 @@
+syntax = "proto3";
+import "google/protobuf/empty.proto";
+
+package decide;
+
+/* The payload for a requested state change to a component. Component state may
+   be a scalar (int32) or a label (string) */
+message StateChange {
+  string component = 1;
+  oneof state {
+    int32 scalar = 4;
+    string label = 5;
+  }
+}
+
+/* The payload for a requested change to the parameters for a component */
+message ComponentParams {
+  string component = 1;
+  // The documentation for the component must define how the parameter value will be parsed from the string.
+  map<string, string> parameters = 2;
+}
+
+/* This is what gets sent on the wire */
+message Request {
+  string protocol = 1;
+  oneof request {
+    // request change to state of a component. Reply type is ok or error.
+    StateChange state_change = 2;
+    // request reset to default state; value is name of component. Reply type is ok or error
+    string state_reset = 3;
+    // request lock on experiment; value is name of experiment. Reply type is ok or error
+    string lock_expt = 16;
+    // request unlock of experiment. Reply type is ok or error
+    google.protobuf.Empty unlock_expt = 17;
+    // request shutdown of controller. Reply type is ok or error
+    google.protobuf.Empty shutdown = 18;
+    // request update to parameter values. Reply type is ok or error.
+    ComponentParams set_parameters = 19;
+    // request parameter values for component. Reply type is params or error.
+    string get_parameters = 20;
+    // request config values for component. Reply type is config or error.
+    string get_component_config = 21;
+    // request config identifier for the controller. Reply type is config or error.
+    google.protobuf.Empty get_controller_config = 22;
+  }
+}
+
+/* These are the reply types */
+message Reply {
+  string protocol = 1;
+  oneof reply {
+    // For state_change, state_reset, lock_expt, unlock_expt, shutdown:
+    // indicates the request was correctly formed and was acted on
+    google.protobuf.Empty ok = 2;
+    // indicates an error with the request, contents give the cause
+    string error = 3;
+    // reply to get_parameters
+    map<string, string> params = 19;
+    // reply to get_component_config, and get_controller_config
+    map<string, string> config = 20;
+  }
+}
+
+/* In ZMQ, the first frame of a PUB message is the topic. In this protocol, the
+ * topic is used to specify the message type, allowing receivers to filter what
+ * they want to see. There are three main topics: `state` for state changes,
+ * `error` for fatal error messages, and `log` for informative log messages. The
+ * same protobuf type is used for all three. For error and log messages, the
+ * human-readable explanation is stored in the `label` field.
+ */
+message Pub {
+  uint64 time = 1;
+  string component = 2;
+  oneof value {
+    int scalar = 3;
+    string label = 4;
+  }
+}


### PR DESCRIPTION
Here is an initial stab at a proto file. A few points to discuss:

- Do we need to support more state types? Right now I just define an int or a string.

- Can we restrict the type of the parameter/config values more? Currently I have it as a string that the controller will have to parse, but we could make it more restrictive to shift some of the burden to the client. Parameter values are probably mostly ints, floats and strings, but the configs might be more complex (i.e. some nesting or lists)